### PR TITLE
Fix: Datenschutzerklärung aus Website-Inhalten (Issue #11) übernehmen + de/en

### DIFF
--- a/messages/de.json
+++ b/messages/de.json
@@ -30,7 +30,59 @@
   },
   "Privacy": {
     "title": "Datenschutzerklärung",
-    "placeholderTitle": "Platzhalter",
-    "placeholderText": "Diese Datenschutzerklärung ist aktuell ein bewusst gekennzeichneter Platzhalter und wird in einem nachfolgenden Schritt vollständig ausgearbeitet."
+    "intro": {
+      "heading": "1. Einleitung",
+      "body": "Diese Datenschutzerklärung informiert über Art, Umfang und Zweck der Verarbeitung personenbezogener Daten beim Besuch dieser Website. Die Inhalte basieren auf der erfassten Struktur aus Issue #11."
+    },
+    "controller": {
+      "heading": "2. Verantwortlicher",
+      "phone": "Telefon: 015251600215",
+      "email": "E-Mail: marius@mxdigital.de"
+    },
+    "logfiles": {
+      "heading": "3. Datenerfassung beim Websitebesuch (Server-Logfiles)",
+      "body": "Beim Aufruf der Website werden technisch erforderliche Informationen automatisiert in Server-Logfiles gespeichert, um Stabilität, Sicherheit und Fehleranalyse zu gewährleisten.",
+      "items": {
+        "ip": "IP-Adresse des anfragenden Geräts",
+        "datetime": "Datum und Uhrzeit des Zugriffs",
+        "request": "Aufgerufene URL/Datei",
+        "referrer": "Referrer-URL",
+        "userAgent": "Browsertyp und Betriebssystem (User-Agent)",
+        "status": "HTTP-Statuscode und übertragene Datenmenge"
+      },
+      "encryption": "Die Übertragung zwischen Browser und Website erfolgt verschlüsselt (SSL/TLS)."
+    },
+    "cookies": {
+      "heading": "4. Cookies",
+      "body": "Die Website kann technisch notwendige Session-Cookies und – je nach eingesetzten Funktionen – persistente Cookies verwenden. Sie dienen der technischen Bereitstellung und Verbesserung der Nutzung.",
+      "legalBasis": "Rechtsgrundlage: berechtigtes Interesse an einer sicheren und funktionsfähigen Website sowie, soweit erforderlich, Einwilligung."
+    },
+    "contact": {
+      "heading": "5. Kontaktaufnahme",
+      "body": "Wenn Sie per E-Mail oder auf anderem Weg Kontakt aufnehmen, werden die übermittelten Daten zur Bearbeitung Ihrer Anfrage und für mögliche Anschlussfragen verarbeitet.",
+      "legalBasis": "Rechtsgrundlage: Vertragserfüllung/vorvertragliche Kommunikation, berechtigtes Interesse und ggf. Einwilligung."
+    },
+    "tools": {
+      "heading": "6. Seitenfunktionalitäten und Drittanbieter",
+      "body": "Sofern externe Dienste wie z. B. Google Web Fonts eingesetzt werden, kann es zu einer Übermittlung personenbezogener Daten an Drittanbieter kommen.",
+      "todo": "TODO: Konkrete eingesetzte Dienste, technische Einbindung, Rechtsgrundlage und Drittlandtransfer je Dienst final dokumentieren."
+    },
+    "rights": {
+      "heading": "7. Rechte betroffener Personen",
+      "items": {
+        "access": "Auskunft über gespeicherte personenbezogene Daten",
+        "rectification": "Berichtigung unrichtiger Daten",
+        "erasure": "Löschung der Daten, soweit keine Aufbewahrungspflichten entgegenstehen",
+        "restriction": "Einschränkung der Verarbeitung",
+        "portability": "Datenübertragbarkeit",
+        "objection": "Widerspruch gegen die Verarbeitung aus Gründen, die sich aus Ihrer besonderen Situation ergeben",
+        "withdrawal": "Widerruf erteilter Einwilligungen mit Wirkung für die Zukunft",
+        "complaint": "Beschwerde bei einer zuständigen Datenschutzaufsichtsbehörde"
+      }
+    },
+    "retention": {
+      "heading": "8. Speicherdauer",
+      "body": "Personenbezogene Daten werden nur so lange gespeichert, wie es für die jeweiligen Verarbeitungszwecke erforderlich ist oder gesetzliche Aufbewahrungsfristen bestehen. Anschließend werden Daten gelöscht oder anonymisiert."
+    }
   }
 }

--- a/messages/en.json
+++ b/messages/en.json
@@ -29,8 +29,60 @@
     "responsibleHeading": "Responsible for content pursuant to Section 18(2) MStV"
   },
   "Privacy": {
-    "title": "Privacy policy",
-    "placeholderTitle": "Placeholder",
-    "placeholderText": "This privacy policy is currently an explicitly marked placeholder and will be fully completed in a following step."
+    "title": "Privacy Policy",
+    "intro": {
+      "heading": "1. Introduction",
+      "body": "This privacy policy explains the type, scope, and purpose of processing personal data when visiting this website. The structure is based on the captured content from Issue #11."
+    },
+    "controller": {
+      "heading": "2. Controller",
+      "phone": "Phone: +49 1525 1600215",
+      "email": "Email: marius@mxdigital.de"
+    },
+    "logfiles": {
+      "heading": "3. Data collection when visiting the website (server log files)",
+      "body": "When you access this website, technically required information is automatically stored in server log files to ensure stability, security, and error analysis.",
+      "items": {
+        "ip": "IP address of the requesting device",
+        "datetime": "Date and time of access",
+        "request": "Requested URL/file",
+        "referrer": "Referrer URL",
+        "userAgent": "Browser type and operating system (user agent)",
+        "status": "HTTP status code and transferred data volume"
+      },
+      "encryption": "Data transmission between browser and website is encrypted (SSL/TLS)."
+    },
+    "cookies": {
+      "heading": "4. Cookies",
+      "body": "The website may use technically necessary session cookies and, depending on implemented features, persistent cookies. They are used for technical operation and to improve usability.",
+      "legalBasis": "Legal basis: legitimate interest in a secure and functional website and, where required, your consent."
+    },
+    "contact": {
+      "heading": "5. Contact requests",
+      "body": "If you contact us via email or other channels, the submitted data is processed to handle your request and potential follow-up communication.",
+      "legalBasis": "Legal basis: contract performance/pre-contractual communication, legitimate interest, and where applicable, consent."
+    },
+    "tools": {
+      "heading": "6. Website features and third-party services",
+      "body": "If external services such as Google Web Fonts are used, personal data may be transmitted to third-party providers.",
+      "todo": "TODO: Finalize documentation of the exact services used, technical integration, legal basis, and third-country transfer details per service."
+    },
+    "rights": {
+      "heading": "7. Data subject rights",
+      "items": {
+        "access": "Right of access to stored personal data",
+        "rectification": "Right to rectification of inaccurate data",
+        "erasure": "Right to erasure, provided no statutory retention duties apply",
+        "restriction": "Right to restriction of processing",
+        "portability": "Right to data portability",
+        "objection": "Right to object to processing based on your particular situation",
+        "withdrawal": "Right to withdraw granted consent with effect for the future",
+        "complaint": "Right to lodge a complaint with a competent data protection supervisory authority"
+      }
+    },
+    "retention": {
+      "heading": "8. Storage period",
+      "body": "Personal data is stored only as long as necessary for the respective processing purpose or as required by statutory retention periods. Data is then deleted or anonymized."
+    }
   }
 }

--- a/src/app/[locale]/datenschutz/page.tsx
+++ b/src/app/[locale]/datenschutz/page.tsx
@@ -9,13 +9,89 @@ export default async function PrivacyPolicyPage({params}: PrivacyPolicyPageProps
   setRequestLocale(locale);
   const t = await getTranslations("Privacy");
 
+  const logItems = [
+    t("logfiles.items.ip"),
+    t("logfiles.items.datetime"),
+    t("logfiles.items.request"),
+    t("logfiles.items.referrer"),
+    t("logfiles.items.userAgent"),
+    t("logfiles.items.status"),
+  ];
+
+  const rightsItems = [
+    t("rights.items.access"),
+    t("rights.items.rectification"),
+    t("rights.items.erasure"),
+    t("rights.items.restriction"),
+    t("rights.items.portability"),
+    t("rights.items.objection"),
+    t("rights.items.withdrawal"),
+    t("rights.items.complaint"),
+  ];
+
   return (
     <section className="mx-auto w-full max-w-3xl px-6 py-16 sm:px-10">
       <h1 className="text-3xl font-semibold tracking-tight sm:text-4xl">{t("title")}</h1>
 
-      <div className="mt-8 rounded-lg border border-amber-500/40 bg-amber-500/10 p-4 text-amber-100">
-        <p className="font-medium">{t("placeholderTitle")}</p>
-        <p className="mt-2 text-sm leading-6">{t("placeholderText")}</p>
+      <div className="mt-8 space-y-8 text-neutral-200">
+        <section className="space-y-3">
+          <h2 className="text-xl font-medium">{t("intro.heading")}</h2>
+          <p className="text-sm leading-6 text-neutral-300">{t("intro.body")}</p>
+        </section>
+
+        <section className="space-y-3">
+          <h2 className="text-xl font-medium">{t("controller.heading")}</h2>
+          <div className="space-y-1 text-sm text-neutral-300">
+            <p>Marius Schäffer</p>
+            <p>MX Digital</p>
+            <p>Virchowstraße 3, 04157 Leipzig</p>
+            <p>{t("controller.phone")}</p>
+            <p>{t("controller.email")}</p>
+          </div>
+        </section>
+
+        <section className="space-y-3">
+          <h2 className="text-xl font-medium">{t("logfiles.heading")}</h2>
+          <p className="text-sm leading-6 text-neutral-300">{t("logfiles.body")}</p>
+          <ul className="list-disc space-y-1 pl-5 text-sm text-neutral-300">
+            {logItems.map((item) => (
+              <li key={item}>{item}</li>
+            ))}
+          </ul>
+          <p className="text-sm leading-6 text-neutral-300">{t("logfiles.encryption")}</p>
+        </section>
+
+        <section className="space-y-3">
+          <h2 className="text-xl font-medium">{t("cookies.heading")}</h2>
+          <p className="text-sm leading-6 text-neutral-300">{t("cookies.body")}</p>
+          <p className="text-sm leading-6 text-neutral-300">{t("cookies.legalBasis")}</p>
+        </section>
+
+        <section className="space-y-3">
+          <h2 className="text-xl font-medium">{t("contact.heading")}</h2>
+          <p className="text-sm leading-6 text-neutral-300">{t("contact.body")}</p>
+          <p className="text-sm leading-6 text-neutral-300">{t("contact.legalBasis")}</p>
+        </section>
+
+        <section className="space-y-3">
+          <h2 className="text-xl font-medium">{t("tools.heading")}</h2>
+          <p className="text-sm leading-6 text-neutral-300">{t("tools.body")}</p>
+          <p className="text-sm leading-6 text-amber-200">{t("tools.todo")}</p>
+        </section>
+
+        <section className="space-y-3">
+          <h2 className="text-xl font-medium">{t("rights.heading")}</h2>
+          <ul className="list-disc space-y-1 pl-5 text-sm text-neutral-300">
+            {rightsItems.map((item) => (
+              <li key={item}>{item}</li>
+            ))}
+          </ul>
+        </section>
+
+        <section className="space-y-3">
+          <h2 className="text-xl font-medium">{t("retention.heading")}</h2>
+          <p className="text-sm leading-6 text-neutral-300">{t("retention.body")}</p>
+        </section>
       </div>
     </section>
   );

--- a/src/i18n/routing.ts
+++ b/src/i18n/routing.ts
@@ -4,6 +4,12 @@ export const routing = defineRouting({
   locales: ["de", "en"],
   defaultLocale: "de",
   localePrefix: "always",
+  pathnames: {
+    "/datenschutz": {
+      de: "/datenschutz",
+      en: "/privacy",
+    },
+  },
 });
 
 export type AppLocale = (typeof routing.locales)[number];


### PR DESCRIPTION
## Summary
- Datenschutzerklärung-Inhalte aus #11 übernommen und strukturiert umgesetzt
- Zweisprachig umgesetzt: /de/datenschutz und /en/privacy
- Inhalte de/en gleichwertig gehalten

Fixes #13
cc @mars-mx